### PR TITLE
fix: start express server in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "vite",
+    "dev": "tsx server/index.ts",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- start Express server when running `npm run dev` so API routes like `/api/auth/user` are available during development

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ee72a73608329afb8b6b27f44be43